### PR TITLE
remove zabbix gem dependency

### DIFF
--- a/fluent-plugin-zabbix.gemspec
+++ b/fluent-plugin-zabbix.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |gem|
   gem.version       = "0.0.5"
 
   gem.add_runtime_dependency "fluentd", "~> 0.10"
-  gem.add_runtime_dependency "zabbix", ">= 0.4"
+  gem.add_runtime_dependency "yajl-ruby", "~> 1.0"
   gem.add_development_dependency "rake", ">= 0.9.2"
   gem.add_development_dependency "glint", "= 0.0.2"
 end


### PR DESCRIPTION
zabbix gem is too old (last released at 2011), and repository https://github.com/mhat/zabbix is closed.
