### PR TITLE
Migrate to v0.14 API

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -9,4 +9,4 @@ Rake::TestTask.new(:test) do |test|
   test.verbose = true
 end
 
-task :default => :test
+task default: :test

--- a/fluent-plugin-zabbix.gemspec
+++ b/fluent-plugin-zabbix.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = "0.2.0"
 
-  gem.add_runtime_dependency "fluentd", [">= 0.10", "< 2"]
+  gem.add_runtime_dependency "fluentd", [">= 0.14.8", "< 2"]
   gem.add_runtime_dependency "yajl-ruby", "~> 1.0"
   gem.add_runtime_dependency "fluent-mixin-config-placeholders", "~> 0.3"
   gem.add_development_dependency "rake", ">= 0.9.2"

--- a/lib/fluent/plugin/out_zabbix.rb
+++ b/lib/fluent/plugin/out_zabbix.rb
@@ -19,11 +19,6 @@ class Fluent::Plugin::ZabbixOutput < Fluent::Plugin::Output
 
   include Fluent::Mixin::ConfigPlaceholders
 
-  # Define `log` method for v0.10.42 or earlier
-  unless method_defined?(:log)
-    define_method("log") { $log }
-  end
-
   def configure(conf)
     super
 

--- a/lib/fluent/plugin/out_zabbix.rb
+++ b/lib/fluent/plugin/out_zabbix.rb
@@ -13,13 +13,13 @@ class Fluent::Plugin::ZabbixOutput < Fluent::Plugin::Output
   end
 
   config_param :zabbix_server, :string
-  config_param :port, :integer,            :default => 10051
-  config_param :host, :string,             :default => Socket.gethostname
-  config_param :host_key, :string,         :default => nil
-  config_param :name_keys, :string,        :default => nil
-  config_param :name_key_pattern, :string, :default => nil
-  config_param :add_key_prefix, :string,   :default => nil
-  config_param :prefix_key, :string,       :default => nil
+  config_param :port, :integer,            default: 10051
+  config_param :host, :string,             default: Socket.gethostname
+  config_param :host_key, :string,         default: nil
+  config_param :name_keys, :string,        default: nil
+  config_param :name_key_pattern, :string, default: nil
+  config_param :add_key_prefix, :string,   default: nil
+  config_param :prefix_key, :string,       default: nil
 
   include Fluent::Mixin::ConfigPlaceholders
 
@@ -83,10 +83,10 @@ class Fluent::Plugin::ZabbixOutput < Fluent::Plugin::Output
         bulk = []
         @name_keys.each {|key|
           if record[key]
-            bulk.push({ :key => format_key(tag, key, record),
-                        :value => format_value(record[key]),
-                        :host => host,
-                        :time => time.to_i,
+            bulk.push({ key: format_key(tag, key, record),
+                        value: format_value(record[key]),
+                        host: host,
+                        time: time.to_i,
                       })
           end
         }
@@ -98,10 +98,10 @@ class Fluent::Plugin::ZabbixOutput < Fluent::Plugin::Output
         bulk = []
         record.keys.each {|key|
           if @name_key_pattern.match(key) && record[key]
-            bulk.push({ :key => format_key(tag, key, record),
-                        :value => format_value(record[key]),
-                        :host => host,
-                        :time => time.to_i,
+            bulk.push({ key: format_key(tag, key, record),
+                        value: format_value(record[key]),
+                        host: host,
+                        time: time.to_i,
                       })
           end
         }
@@ -154,9 +154,9 @@ class Fluent::Plugin::ZabbixOutput < Fluent::Plugin::Output
 
   def send_to_zabbix(sock, time, bulk)
     req = Yajl::Encoder.encode({
-      :request => 'agent data',
-      :clock => time.to_i,
-      :data => bulk,
+      request: 'agent data',
+      clock: time.to_i,
+      data: bulk,
     })
     sock.write(ZBXD + [ req.size ].pack('q') + req)
     sock.flush

--- a/lib/fluent/plugin/out_zabbix.rb
+++ b/lib/fluent/plugin/out_zabbix.rb
@@ -1,6 +1,7 @@
+require 'fluent/plugin/output'
 require 'fluent/mixin/config_placeholders'
 
-class Fluent::ZabbixOutput < Fluent::Output
+class Fluent::Plugin::ZabbixOutput < Fluent::Plugin::Output
   Fluent::Plugin.register_output('zabbix', self)
 
   ZBXD = "ZBXD\x01"
@@ -75,7 +76,7 @@ class Fluent::ZabbixOutput < Fluent::Output
     end
   end
 
-  def emit(tag, es, chain)
+  def process(tag, es)
     if @name_keys
       es.each {|time,record|
         host = gen_host(record)
@@ -107,7 +108,6 @@ class Fluent::ZabbixOutput < Fluent::Output
         send(time, bulk) if bulk.size > 0
       }
     end
-    chain.next
   end
 
   def gen_host(record)

--- a/lib/fluent/plugin/out_zabbix.rb
+++ b/lib/fluent/plugin/out_zabbix.rb
@@ -1,3 +1,5 @@
+require 'socket'
+require 'yajl'
 require 'fluent/plugin/output'
 require 'fluent/mixin/config_placeholders'
 
@@ -5,12 +7,6 @@ class Fluent::Plugin::ZabbixOutput < Fluent::Plugin::Output
   Fluent::Plugin.register_output('zabbix', self)
 
   ZBXD = "ZBXD\x01"
-
-  def initialize
-    super
-    require 'socket'
-    require 'yajl'
-  end
 
   config_param :zabbix_server, :string
   config_param :port, :integer,            default: 10051

--- a/test/plugin/test_out_zabbix.rb
+++ b/test/plugin/test_out_zabbix.rb
@@ -1,4 +1,5 @@
 require 'helper'
+require 'fluent/test/driver/output'
 
 if ENV['LIVE_TEST']
   require "glint"
@@ -25,21 +26,22 @@ class ZabbixOutputTest < Test::Unit::TestCase
     name_keys      foo, bar, baz, f1, f2
   ]
 
-  def create_driver(conf = CONFIG, tag='test')
-    Fluent::Test::OutputTestDriver.new(Fluent::ZabbixOutput, tag).configure(conf)
+  def create_driver(conf = CONFIG)
+    Fluent::Test::Driver::Output.new(Fluent::Plugin::ZabbixOutput).configure(conf)
   end
 
   def test_write
     d = create_driver
     if ENV['LIVE_TEST']
-      d.emit({"foo" => "test value of foo"})
-      d.emit({"bar" => "test value of bar"})
-      d.emit({"baz" => 123.4567 })
-      d.emit({"foo" => "yyy", "zabbix_host" => "alternative-hostname"})
-      d.emit({"f1" => 0.000001})
-      d.emit({"f2" => 0.01})
-      d.run
-      sleep 1
+      d.run(default_tag: 'test') do
+        d.feed({"foo" => "test value of foo"})
+        d.feed({"bar" => "test value of bar"})
+        d.feed({"baz" => 123.4567 })
+        d.feed({"foo" => "yyy", "zabbix_host" => "alternative-hostname"})
+        d.feed({"f1" => 0.000001})
+        d.feed({"f2" => 0.01})
+        sleep 1
+      end
       $server.stop
       assert_equal open($dir + "/trapper.log").read, <<END
 host:test_host	key:test.foo	value:test value of foo
@@ -60,8 +62,8 @@ END
     name_keys      foo, bar, baz
   ]
 
-  def create_driver_host_key(conf = CONFIG_HOST_KEY, tag='test')
-    Fluent::Test::OutputTestDriver.new(Fluent::ZabbixOutput, tag).configure(conf)
+  def create_driver_host_key(conf = CONFIG_HOST_KEY)
+    Fluent::Test::Driver::Output.new(Fluent::Plugin::ZabbixOutput).configure(conf)
   end
 
   CONFIG_PREFIX_KEY = %[
@@ -71,17 +73,18 @@ END
     name_keys      foo, bar, baz
   ]
 
-  def create_driver_prefix_key(conf = CONFIG_PREFIX_KEY, tag='test')
-    Fluent::Test::OutputTestDriver.new(Fluent::ZabbixOutput, tag).configure(conf)
+  def create_driver_prefix_key(conf = CONFIG_PREFIX_KEY)
+    Fluent::Test::Driver::Output.new(Fluent::Plugin::ZabbixOutput).configure(conf)
   end
 
   def test_write_host_key
     d = create_driver_host_key
     if ENV['LIVE_TEST']
-      d.emit({"foo" => "AAA" })
-      d.emit({"foo" => "BBB", "host" => "alternative-hostname"})
-      d.run
-      sleep 1
+      d.run(default_tag: 'test') do
+        d.feed({"foo" => "AAA" })
+        d.feed({"foo" => "BBB", "host" => "alternative-hostname"})
+        sleep 1
+      end
       $server.stop
       assert_equal open($dir + "/trapper.log").read, <<END
 host:test_host	key:test.foo	value:AAA
@@ -93,10 +96,11 @@ END
   def test_write_prefix_key
     d = create_driver_prefix_key
     if ENV['LIVE_TEST']
-      d.emit({"foo" => "AAA"})
-      d.emit({"foo" => "BBB", "prefix" => "p"})
-      d.run
-      sleep 1
+      d.run(default_tag: 'test') do
+        d.feed({"foo" => "AAA"})
+        d.feed({"foo" => "BBB", "prefix" => "p"})
+        sleep 1
+      end
       $server.stop
       assert_equal open($dir + "/trapper.log").read, <<END
 host:test_host	key:foo	value:AAA

--- a/test/plugin/test_out_zabbix.rb
+++ b/test/plugin/test_out_zabbix.rb
@@ -12,7 +12,7 @@ class ZabbixOutputTest < Test::Unit::TestCase
     Fluent::Test.setup
     if ENV['LIVE_TEST']
       $dir = Dir.mktmpdir
-      $server = Glint::Server.new(10051, { :timeout => 3 }) do |port|
+      $server = Glint::Server.new(10051, { timeout: 3 }) do |port|
         exec "./mockserver", $dir.to_s + "/trapper.log"
       end
       $server.start


### PR DESCRIPTION
Hi, I've tried to migrate using v0.14 API.
Could you consider to start using v0.14 API in this plugin?

Please refer to [the upgrading v0.12 to v0.14 guide](http://docs.fluentd.org/v0.14/articles/plugin-update-from-v12) in more details.
