### PR TITLE
Rename ZabbixOutput#send to ZabbixOutput#bulk_send

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ rvm:
   - 2.1
   - 2.2
   - 2.3
-  - 2.4
+  - 2.4.0
 gemfile:
   - Gemfile
 before_install:

--- a/lib/fluent/plugin/out_zabbix.rb
+++ b/lib/fluent/plugin/out_zabbix.rb
@@ -48,7 +48,7 @@ class Fluent::Plugin::ZabbixOutput < Fluent::Plugin::Output
     super
   end
 
-  def send(time, bulk)
+  def bulk_send(time, bulk)
     bulk.each do |d|
     end
     begin
@@ -81,7 +81,7 @@ class Fluent::Plugin::ZabbixOutput < Fluent::Plugin::Output
                       })
           end
         }
-        send(time, bulk) if bulk.size > 0
+        bulk_send(time, bulk) if bulk.size > 0
       }
     else # for name_key_pattern
       es.each {|time,record|
@@ -96,7 +96,7 @@ class Fluent::Plugin::ZabbixOutput < Fluent::Plugin::Output
                       })
           end
         }
-        send(time, bulk) if bulk.size > 0
+        bulk_send(time, bulk) if bulk.size > 0
       }
     end
   end


### PR DESCRIPTION
Hello,

`ZabbixOutput#send` overrides `(other class)#send` (probably..) .

So the following error occurs at shutdown:

```
2017-03-15 04:11:38 +0000 [warn]: #0 unexpected error while calling after_shutdown on output plugin pluguin=Fluent::ZabbixOutput plugin_id="..." error_class=ArgumentError error="wrong number of arguments (1 for 2)"
  2017-03-15 04:11:38 +0000 [warn]: #0 /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluent-plugin-zabbix-0.2.1/lib/fluent/plugin/out_zabbix.rb:59:in `send'
  2017-03-15 04:11:38 +0000 [warn]: #0 /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-0.14.13/lib/fluent/root_agent.rb:174:in `block (2 levels) in shutdown'
  2017-03-15 04:11:38 +0000 [warn]: #0 /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-0.14.13/lib/fluent/root_agent.rb:117:in `block (2 levels) in lifecycle'
  2017-03-15 04:11:38 +0000 [warn]: #0 /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-0.14.13/lib/fluent/agent.rb:118:in `block (2 levels) in lifecycle'
  2017-03-15 04:11:38 +0000 [warn]: #0 /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-0.14.13/lib/fluent/agent.rb:117:in `each'
  2017-03-15 04:11:38 +0000 [warn]: #0 /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-0.14.13/lib/fluent/agent.rb:117:in `block in lifecycle'
  2017-03-15 04:11:38 +0000 [warn]: #0 /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-0.14.13/lib/fluent/agent.rb:110:in `each'
  2017-03-15 04:11:38 +0000 [warn]: #0 /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-0.14.13/lib/fluent/agent.rb:110:in `lifecycle'
  2017-03-15 04:11:38 +0000 [warn]: #0 /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-0.14.13/lib/fluent/root_agent.rb:116:in `block in lifecycle'
  2017-03-15 04:11:38 +0000 [warn]: #0 /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-0.14.13/lib/fluent/root_agent.rb:113:in `each'
  2017-03-15 04:11:38 +0000 [warn]: #0 /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-0.14.13/lib/fluent/root_agent.rb:113:in `lifecycle'
  2017-03-15 04:11:38 +0000 [warn]: #0 /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-0.14.13/lib/fluent/root_agent.rb:171:in `block in shutdown'
  2017-03-15 04:11:38 +0000 [warn]: #0 /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-0.14.13/lib/fluent/root_agent.rb:221:in `call'
  2017-03-15 04:11:38 +0000 [warn]: #0 /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-0.14.13/lib/fluent/root_agent.rb:221:in `shutdown'
  2017-03-15 04:11:38 +0000 [warn]: #0 /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-0.14.13/lib/fluent/engine.rb:261:in `shutdown'
  2017-03-15 04:11:38 +0000 [warn]: #0 /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-0.14.13/lib/fluent/engine.rb:237:in `run'
  2017-03-15 04:11:38 +0000 [warn]: #0 /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-0.14.13/lib/fluent/supervisor.rb:728:in `run_engine'
  2017-03-15 04:11:38 +0000 [warn]: #0 /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-0.14.13/lib/fluent/supervisor.rb:495:in `block in run_worker'
  2017-03-15 04:11:38 +0000 [warn]: #0 /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-0.14.13/lib/fluent/supervisor.rb:652:in `call'
  2017-03-15 04:11:38 +0000 [warn]: #0 /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-0.14.13/lib/fluent/supervisor.rb:652:in `main_process'
  2017-03-15 04:11:38 +0000 [warn]: #0 /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-0.14.13/lib/fluent/supervisor.rb:490:in `run_worker'
  2017-03-15 04:11:38 +0000 [warn]: #0 /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-0.14.13/lib/fluent/command/fluentd.rb:300:in `<top (required)>'
  2017-03-15 04:11:38 +0000 [warn]: #0 /opt/td-agent/embedded/lib/ruby/site_ruby/2.1.0/rubygems/core_ext/kernel_require.rb:54:in `require'
  2017-03-15 04:11:38 +0000 [warn]: #0 /opt/td-agent/embedded/lib/ruby/site_ruby/2.1.0/rubygems/core_ext/kernel_require.rb:54:in `require'
  2017-03-15 04:11:38 +0000 [warn]: #0 /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-0.14.13/bin/fluentd:5:in `<top (required)>'
  2017-03-15 04:11:38 +0000 [warn]: #0 /opt/td-agent/embedded/bin/fluentd:23:in `load'
  2017-03-15 04:11:38 +0000 [warn]: #0 /opt/td-agent/embedded/bin/fluentd:23:in `<top (required)>'
  2017-03-15 04:11:38 +0000 [warn]: #0 /usr/sbin/td-agent:7:in `load'
  2017-03-15 04:11:38 +0000 [warn]: #0 /usr/sbin/td-agent:7:in `<main>'
```

Please merge If there is no problem 🙏 

## env
- td-agent/xenial,now 2.3.4-0 amd64
- fluent-plugin-zabbix (0.2.1)
