### PR TITLE
Change request value 'agent data' to 'sender data'.

### DIFF
--- a/lib/fluent/plugin/out_zabbix.rb
+++ b/lib/fluent/plugin/out_zabbix.rb
@@ -7,6 +7,7 @@ class Fluent::Plugin::ZabbixOutput < Fluent::Plugin::Output
   Fluent::Plugin.register_output('zabbix', self)
 
   ZBXD = "ZBXD\x01"
+  ZBX_PROTO_VALUE_SENDER_DATA = 'sender data'
 
   config_param :zabbix_server, :string
   config_param :port, :integer,            default: 10051
@@ -141,7 +142,7 @@ class Fluent::Plugin::ZabbixOutput < Fluent::Plugin::Output
 
   def send_to_zabbix(sock, time, bulk)
     req = Yajl::Encoder.encode({
-      request: 'agent data',
+      request: ZBX_PROTO_VALUE_SENDER_DATA,
       clock: time.to_i,
       data: bulk,
     })


### PR DESCRIPTION
https://support.zabbix.com/browse/ZBXNEXT-1804
https://github.com/zabbix/zabbix/commit/27830e25df8b03aadcd694d4c512d83b1c50e1e2

Zabbix >= 3.4 trapper do not accept 'agent data'.