### PR TITLE
Fix timestamp keys for Zabbix sender request

### DIFF
--- a/lib/fluent/plugin/out_zabbix.rb
+++ b/lib/fluent/plugin/out_zabbix.rb
@@ -70,7 +70,7 @@ class Fluent::Plugin::ZabbixOutput < Fluent::Plugin::Output
             bulk.push({ key: format_key(tag, key, record),
                         value: format_value(record[key]),
                         host: host,
-                        time: time.to_i,
+                        clock: time.to_i,
                       })
           end
         }
@@ -85,7 +85,7 @@ class Fluent::Plugin::ZabbixOutput < Fluent::Plugin::Output
             bulk.push({ key: format_key(tag, key, record),
                         value: format_value(record[key]),
                         host: host,
-                        time: time.to_i,
+                        clock: time.to_i,
                       })
           end
         }


### PR DESCRIPTION
According to the Zabbix documentation, the key for timestamps is expected to be `clock`. [^zabi]
In my fluentd+Zabbix setup, this modification resolved the issue of Zabbix not recognizing the timestamps of older events.

[^zabi]: https://www.zabbix.com/documentation/current/en/manual/appendix/items/trapper
