### PR TITLE
Fix timestamp keys for Zabbix sender request (backport #22 to v0.12)

### DIFF
--- a/lib/fluent/plugin/out_zabbix.rb
+++ b/lib/fluent/plugin/out_zabbix.rb
@@ -86,7 +86,7 @@ class Fluent::ZabbixOutput < Fluent::Output
             bulk.push({ :key => format_key(tag, key, record),
                         :value => format_value(record[key]),
                         :host => host,
-                        :time => time.to_i,
+                        :clock => time.to_i,
                       })
           end
         }
@@ -101,7 +101,7 @@ class Fluent::ZabbixOutput < Fluent::Output
             bulk.push({ :key => format_key(tag, key, record),
                         :value => format_value(record[key]),
                         :host => host,
-                        :time => time.to_i,
+                        :clock => time.to_i,
                       })
           end
         }


### PR DESCRIPTION
Due to some reasons, I'm currently running fluentd v0.12 also. While I acknowledge that v0.12 may be deemed outdated, I would be grateful if we could consider a backport to the fluentd-v0.12 branch...!